### PR TITLE
Accessibility improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
 
 <body onload="fillSiteTable(`fromLoading`)">
 	<div id="webringTorus"></div>
-	<button class="sticky" id="seWebringLogo"><a href="https://github.com/simcard0000/se-webring" target="_blank"><img src="./assets/logo/logo_bg_b.png" 
-		alt="SE Webring repository link" width="50" height="50"/></a></button>
+	<div class="sticky" id="seWebringLogo"><a href="https://github.com/simcard0000/se-webring" target="_blank"><img src="./assets/logo/logo_bg_b.png" 
+		alt="SE Webring repository link" width="50" height="50"/></a></div>
 	<div id="centeredContent">
 		<div class="sticky" id="searchbarSection">
 			<img id="searchbarIcon" src="./assets/search.svg" alt="Search site icon" width="15" height="15"/>

--- a/js/se-webring.js
+++ b/js/se-webring.js
@@ -206,16 +206,16 @@ function fillSiteTable(type) {
         oldTable.remove();
     }
     let htmlContent = [];
-    htmlContent.push("<div class=\"sticky\" id=\"mainTable\">");
+    htmlContent.push("<ul class=\"sticky\" id=\"mainTable\">");
     for (let i = 0; i < siteArray.length; i++) {
         let cleanSite = new URL(siteArray[i]["website"]);
         let host = cleanSite.hostname;
         if (host.substring(0, 4) === "www."){
             host = host.substring(4, host.length);
         }
-        htmlContent.push("<button><a target=\"_blank\" href=\"" + cleanSite.toString() + "\">" + host + "</a></button>");
+        htmlContent.push("<li><a target=\"_blank\" href=\"" + cleanSite.toString() + "\">" + host + "</a></li>");
     }
-    htmlContent.push("</div>");
+    htmlContent.push("</ul>");
     divSiteList.insertAdjacentHTML(
          "afterend",
          htmlContent.join('')

--- a/se-webring.css
+++ b/se-webring.css
@@ -29,13 +29,12 @@ a, p {
 }
 
 a:hover,
-button:focus,
 a:focus {
   color: white;
   transition: 1s;
 }
 
-button {
+#mainTable > li {
   border: 0;
   background-color: transparent;
   outline: none;
@@ -108,6 +107,7 @@ input[type="search"]::-webkit-search-results-decoration {
 }
 
 #mainTable {
+  list-style: none;
   /* position: relative; */
   display: flex;
   align-items: center;


### PR DESCRIPTION
* The `<button>` tag surrounding links make keyboard navigation confusing. The button can be focused separately from the link inside, and furthermore, the button has no focused style. This changes the buttons to non-interactive elements.

* This also changes the list of links to use a `<ul>` tag, so it is semantically a list, allowing screen readers to announce it as such.
